### PR TITLE
change CI slack notification channel and frequency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,11 @@ script:
     - platformio ci --board=teensy36
 
 notifications:
-    slack: electriccarteam:asuKUGdj8PTljANmYngSspek
+    slack: 
+        rooms: 
+            - electriccarteam:asuKUGdj8PTljANmYngSspek#builds
+        on_success: change
+        on_failure: always
 
 
 #


### PR DESCRIPTION
Slack notifications will not post in #builds channel.
Notifications will ALWAYS be sent for failure; for success, a notification will only be sent if the previous build failed.