### PR TITLE
#130 #128 #106 implements pedal tolerance and if brake is pressed 

### DIFF
--- a/MainBrain/src/Controller/PedalController/PedalController.cpp
+++ b/MainBrain/src/Controller/PedalController/PedalController.cpp
@@ -125,7 +125,16 @@ bool PedalController::isImplausibilityGas(void)
  */
 float PedalController::getPercentageBrake(void)
 {
-    return 0.0; //TODO: Implement
+    brakeModel->update();
+
+    float percentageValue = ((float)brakeModel->getRawValue()) / MAX_ANALOGREAD;
+
+    if (percentageValue<=20)    //this number may need to be change on how the brake pot acts
+    {
+        percentageValue=0;
+    }
+
+    return percentageValue; 
 }
 
 

--- a/MainBrain/src/Controller/PedalController/PedalController.cpp
+++ b/MainBrain/src/Controller/PedalController/PedalController.cpp
@@ -92,6 +92,11 @@ float PedalController::getPercentageGas(void)
     // float percentageValue = ((float)gasModel->getRawValue() - (float)gasModel->getRawOrigin()) / (MAX_ANALOGREAD - (float)gasModel->getRawOrigin());    
     float percentageValue = ((float)gasModel->getRawValue()) / MAX_ANALOGREAD;
 
+    //tolerance for gas pedal and handles brake pressed
+    if (percentageValue<=20 || PedalController::getPercentageBrake()>0){
+        percentageValue = 0;
+    }
+
     return percentageValue; 
 }
 


### PR DESCRIPTION
Fixes #
Statement added allows for tolerance of pedal so small rpm values are blocked from MC.

## Proposed Changes

  - Pedal tolerance
  - Solution to situation when brake is pressed and speed value needs to be set to zero so motor can spin free.
  